### PR TITLE
Add passport routes to CORS middleware

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -17,6 +17,7 @@ use App\Models\FolderRequest;
 
 use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
 class AuthServiceProvider extends ServiceProvider
@@ -45,6 +46,8 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
-        Passport::routes();
+        Route::group([ 'middleware' => \Barryvdh\Cors\HandleCors::class], function() {
+            Passport::routes();
+        });
     }
 }


### PR DESCRIPTION
To prevent cross origin error while using passport routes, they should stay inside CORS middleware.